### PR TITLE
Allow older version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Caffeine Puppet Module for Boxen
+# Skitch Puppet Module for Boxen
 
-Install [Caffeine](http://lightheadsw.com/caffeine), insomnia for your Mac.
+Install [Skitch](http://evernote.com/skitch/) for your Mac.
 
 ## Usage
 
 ```puppet
-include caffeine
+include skitch
+```
+
+It's also optional to install the older version of skitch:
+
+```puppet
+include skitch::legacy
 ```
 
 ## Required Puppet Modules

--- a/manifests/legacy.pp
+++ b/manifests/legacy.pp
@@ -1,0 +1,11 @@
+# Public: Install Skitch.app to /Applications.
+#
+# Examples
+#
+#   include skitch::legacy
+class skitch::legacy {
+  package { 'Skitch-1x':
+    provider => 'compressed_app',
+    source   => 'http://www.macupdate.com/download/39932/Skitch-1.0.12.zip'
+  }
+}


### PR DESCRIPTION
  Add legacy installer
    
 Some people don't like the newer skitch. I'm one of them. So, I'll allow
 for an older version of skitch to be installed.
    
 See
    http://www.tuaw.com/2012/09/20/skitch-2-0-is-like-skitch-1-0-without-all-those-pesky-features/
   for some decent reasons why the new version isn't as awesome.
    